### PR TITLE
Use .replace() to sanitize attachment filenames

### DIFF
--- a/src/controllers/tickets.js
+++ b/src/controllers/tickets.js
@@ -573,10 +573,12 @@ ticketsController.uploadAttachment = function(req, res) {
         }
 
         var savePath = path.join(__dirname, '../../public/uploads/tickets', object.ticketId);
+        var sanitizedFilename = filename.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+
         if (!fs.existsSync(savePath)) fs.mkdirSync(savePath);
 
-        object.filePath = path.join(savePath, 'attachment_' + filename);
-        object.filename = filename;
+        object.filePath = path.join(savePath, 'attachment_' + sanitizedFilename);
+        object.filename = sanitizedFilename;
         object.mimetype = mimetype;
 
         if (fs.existsSync(object.filePath)) {


### PR DESCRIPTION
While testing ticket attachments from a 3rd party client app in development, I uploaded a file with a filename containing `#`. Uploaded fine, but obviously of should not be used within a URL. Let's be safe and replace all non alpha-numeric characters in the filename.