### PR TITLE
update v2 accountsApi.create to set accessToken

### DIFF
--- a/src/controllers/api/v2/accounts.js
+++ b/src/controllers/api/v2/accounts.js
@@ -31,6 +31,8 @@ accountsApi.create = function (req, res) {
   async.series(
     {
       user: function (next) {
+        var chance = require('chance').Chance(),
+            accessToken = chance.hash();
         User.create(
           {
             username: postData.username,
@@ -38,7 +40,8 @@ accountsApi.create = function (req, res) {
             password: postData.password,
             fullname: postData.fullname,
             title: postData.title,
-            role: postData.role
+            role: postData.role,
+            accessToken
           },
           function (err, user) {
             if (err) return apiUtil.sendApiError(res, 500, err.message)


### PR DESCRIPTION
Users created manually do not get an accessToken by default and as such can not login.