### PR TITLE
Fixed CreateDepartmentModal Team/Groups Client-Side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## [1.0.14](https://github.com/polonel/trudesk/compare/v1.0.13...v1.0.14) (2019-06-10)
+
+
+### Bug Fixes
+
+* **departments:** issue with creating department with no teams [#206](https://github.com/polonel/trudesk/issues/206) ([94ff47a](https://github.com/polonel/trudesk/commit/94ff47a))
+* **elasticsearch:** remove ticket from index on delete ([1b46ff4](https://github.com/polonel/trudesk/commit/1b46ff4))
+* **mailer:** issue where mail was not being sent ([4f2ba22](https://github.com/polonel/trudesk/commit/4f2ba22))
+
 ## [1.0.13](https://github.com/polonel/trudesk/compare/v1.0.12...v1.0.13) (2019-05-23)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trudesk",
-  "version": "1.0.14-beta",
+  "version": "1.0.14",
   "private": true,
   "engines": {
     "node": ">=9.10.0"

--- a/src/client/containers/Modals/CreateDepartmentModal.jsx
+++ b/src/client/containers/Modals/CreateDepartmentModal.jsx
@@ -60,7 +60,17 @@ class CreateDepartmentModal extends React.Component {
     e.preventDefault()
     const $form = $(e.target)
     if (!$form.isValid(null, null, false)) return false
-
+  
+    if(!this.allGroups && this.groupSelect.getSelected() == null){
+      helpers.UI.showSnackbar('Can not create department without a group selected or all groups enabled!', true)
+      return false;
+    }
+    
+    if(this.teamsSelect.getSelected() == null){
+      helpers.UI.showSnackbar('Can not create department without a team selected!', true)
+      return false;
+    }
+    
     const payload = {
       name: this.name,
       teams: this.teamsSelect.getSelected(),


### PR DESCRIPTION
**The only form validation is on the "DepartmentName" field.** If a user creates a department **without** a team selected, it will break the view window since teams = null and it cant .map() it. This is also the case in which you leave "allGroups" disabled **AND** leaving the groupSelect empty.

Both cases will cause either teams = null or groups = null which breaks the .map() call clientside when rendering the departments page.

This fix prevents bugged Departments from being inserted into Mongo client-side.