### PR TITLE
Fixed Bugged Department Creation Server-Side

### DIFF
--- a/src/controllers/api/v2/departments.js
+++ b/src/controllers/api/v2/departments.js
@@ -28,6 +28,9 @@ apiDepartments.get = function (req, res) {
 apiDepartments.create = function (req, res) {
   var postData = req.body
   if (!postData) return apiUtils.sendApiError_InvalidPostData(res)
+  
+  if (!postData.teams) postData.teams = []
+  if (!postData.groups) postData.groups = []
 
   Department.create(postData, function (err, createdDepartment) {
     if (err) return apiUtils.sendApiError(res, 500, err.message)


### PR DESCRIPTION
To prevent the api from being used improperly without the security of the client-side createdepartmentmodal (post of the v2 api), I've gone ahead and added the protection server-side to ensure that all created departments do not have null properties in the MongoDB document.