### PR TITLE
Fix issue #223, confusion top bar separator.

### DIFF
--- a/src/client/containers/Topbar/TopbarContainer.jsx
+++ b/src/client/containers/Topbar/TopbarContainer.jsx
@@ -148,8 +148,8 @@ class TopbarContainer extends React.Component {
                       </li>
                     )}
                     {sessionUser && helpers.canUser('tickets:create') && (
-                      <li className='top-bar-icon nopadding'>
-                        <i className='material-icons'>more_vert</i>
+                      <li className='top-bar-icon nopadding nohover'>
+                        <i className='material-icons separator'>remove</i>
                       </li>
                     )}
                     {/* End Create Ticket Perm */}
@@ -190,6 +190,9 @@ class TopbarContainer extends React.Component {
                           </span>
                         </a>
                       </OffCanvasTrigger>
+                    </li>
+                    <li className='top-bar-icon nopadding nohover'>
+                      <i className='material-icons separator'>remove</i>
                     </li>
 
                     <li className='profile-area profile-name'>

--- a/src/sass/_settings_theme_dark.sass
+++ b/src/sass/_settings_theme_dark.sass
@@ -29,6 +29,7 @@ $logo_text_color: #FFFFFF
 $logo_circle_color: #E74C3C
 
 $topbar_bg: darken(#595f69, 10%)
+$topbar_separator: #595f69
 $topbar_icons: #EEEEEE
 $topbar_icons_hover: darken($topbar_icons, 10%)
 $topbar_badge: #E74C3C

--- a/src/sass/mixins.sass
+++ b/src/sass/mixins.sass
@@ -31,3 +31,6 @@
 @mixin square($size)
   height: $size
   width: $size
+
+@mixin rotate($deg)
+  transform: rotate($deg)

--- a/src/sass/partials/topnav.sass
+++ b/src/sass/partials/topnav.sass
@@ -62,7 +62,7 @@
         overflow: hidden
         max-height: 74px
 
-        &:hover
+        &:hover:not(.nohover)
           color: $topbar_icons_hover !important
           i
             color: $topbar_icons_hover !important
@@ -92,6 +92,10 @@
           &.material-icons
             margin-top: 2px
             line-height: 70px
+            &.separator
+              +rotate(90deg)
+              color: $topbar_separator !important
+
         svg
           width: 32px !important
           height: 32px !important
@@ -126,21 +130,9 @@
   color: $topbar_text_color !important
   //background: url("/img/midDots.png") no-repeat
   //background-position: 0 50%
-  margin-left: 10px
-  &:before
-    content: "\E5D4"
-    font-family: 'Material Icons'
-    font-style: normal
-    font-weight: 400
-    color: $topbar_icons
-    font-size: 30px
-    position: absolute
-    left: -10px
-    top: 0
-
   span
     display: inline-block
-    margin: 0 20px 0 15px
+    margin: 0 20px 0 0
     color: $topbar_text_color !important
     &:hover
       color: inherit


### PR DESCRIPTION
I couldn't test the last change building all the application on Docker, but I tested in the Browser, 99% sure it works the same way, blocked by issue #219 on docker.

In this implementation, I'm using icon `remove` rotated at 90 deg. I also changed the separator before the user profile from pseudo-element (`:before`) to a proper HTML element, the pseudo-element was not identical in respect to the appearance.

Added a `nohover` to the icon, so it doesn't get highlighted when the mouse is over it.