### PR TITLE
Fix PR #224

### DIFF
--- a/src/sass/_settings_theme_dark.sass
+++ b/src/sass/_settings_theme_dark.sass
@@ -29,7 +29,6 @@ $logo_text_color: #FFFFFF
 $logo_circle_color: #E74C3C
 
 $topbar_bg: darken(#595f69, 10%)
-$topbar_separator: #595f69
 $topbar_icons: #EEEEEE
 $topbar_icons_hover: darken($topbar_icons, 10%)
 $topbar_badge: #E74C3C

--- a/src/sass/functions.sass
+++ b/src/sass/functions.sass
@@ -44,3 +44,9 @@
     @return #ffffff
   @else
     @return $accent_color
+
+@function topbar-separator-color()
+  @if (lightness($topbar_bg) > 50)
+    @return darken($topbar_bg, 15%)
+  @else
+    @return lighten($topbar_bg, 15%)

--- a/src/sass/partials/topnav.sass
+++ b/src/sass/partials/topnav.sass
@@ -94,7 +94,7 @@
             line-height: 70px
             &.separator
               +rotate(90deg)
-              color: $topbar_separator !important
+              color: topbar-separator-color() !important
 
         svg
           width: 32px !important


### PR DESCRIPTION
I fixed PR #224. I used a different approach. Used a function to darken/lighten the `$topbar_bg` color, so independently of the selected theme, the color has the same visual effect. Also, fixed a bug in the last change.

Some themes results:

![Screen Shot 2019-06-19 at 09 54 05](https://user-images.githubusercontent.com/289289/59767433-b613ea00-9278-11e9-9d13-3c1c88c05d0f.png)

![Screen Shot 2019-06-19 at 09 54 16](https://user-images.githubusercontent.com/289289/59767434-b613ea00-9278-11e9-90b2-8a0843af2b33.png)

![Screen Shot 2019-06-19 at 09 54 34](https://user-images.githubusercontent.com/289289/59767435-b613ea00-9278-11e9-893f-4e9a615f6b6d.png)

![Screen Shot 2019-06-19 at 10 03 28](https://user-images.githubusercontent.com/289289/59767826-82858f80-9279-11e9-9b73-6fe7ad74c563.png)

