### PR TITLE
disable sslv3

### DIFF
--- a/src/mailer/index.js
+++ b/src/mailer/index.js
@@ -85,8 +85,7 @@ function createTransporter (callback) {
       port: mailSettings.port && mailSettings.port.value ? mailSettings.port.value : 25,
       secure: mailSettings.ssl && mailSettings.ssl.value ? mailSettings.ssl.value : false,
       tls: {
-        rejectUnauthorized: false,
-        ciphers: 'SSLv3'
+        rejectUnauthorized: false
       }
     }
     if (mailSettings.username && mailSettings.username.value) {


### PR DESCRIPTION
mail providers like Cpanel (Exim) won't send emails if sslv3 is forced, removing this makes cpanel able to send these emails again