### PR TITLE
Fix password reset mail template

### DIFF
--- a/src/controllers/main.js
+++ b/src/controllers/main.js
@@ -338,7 +338,7 @@ mainController.forgotPass = function (req, res) {
           }
 
           var subject = '[Trudesk] Password Reset Request'
-          if (template) subject = global.HandleBars.compile(template.subject)(data)
+          if (template) subject = global.Handlebars.compile(template.subject)(data)
 
           email
             .render('password-reset', data)


### PR DESCRIPTION
- Fixed a typo that caused trudesk to crash when using the password reset feature in combination with the beta mail templates.

Open question:
- Should this have been caught by automated tests?

Fixes #333