### PR TITLE
Mailer Connection refused due to Gmail TLS Authentication resolved

### DIFF
--- a/src/mailer/mailCheck.js
+++ b/src/mailer/mailCheck.js
@@ -88,7 +88,8 @@ mailCheck.init = function (settings) {
     password: MAILERCHECK_PASS,
     host: MAILERCHECK_HOST,
     port: MAILERCHECK_PORT,
-    tls: MAILERCHECK_TLS
+    tls: MAILERCHECK_TLS,
+    tlsOptions: { rejectUnauthorized: false}
   })
 
   mailCheck.fetchMailOptions = {


### PR DESCRIPTION
Error: self signed certificate 
Solved via adding tlsOptions in mailCheck.js file while connecting.
