### PR TITLE
Use the right encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [1.1.8](https://github.com/polonel/trudesk/compare/v1.1.7...v1.1.8) (2021-07-25)
+
+
+### Bug Fixes
+
+* **tickets:** creation has no response [#423](https://github.com/polonel/trudesk/issues/423) by alsemany ([dcfde5f](https://github.com/polonel/trudesk/commit/dcfde5f))
+
 ## [1.1.7](https://github.com/polonel/trudesk/compare/v1.1.6...v1.1.7) (2021-07-15)
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2014-2019 Trudesk, Inc. 
+Copyright 2014-2021 Trudesk, Inc. 
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trudesk",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "private": true,
   "engines": {
     "node": ">=9.10.0"

--- a/src/controllers/install.js
+++ b/src/controllers/install.js
@@ -54,7 +54,7 @@ installController.elastictest = function (req, res) {
 
 installController.mongotest = function (req, res) {
   var data = req.body
-  var dbPassword = encodeURIComponent(data.password)
+  var dbPassword = encodeURI(data.password)
   var CONNECTION_URI =
     'mongodb://' + data.username + ':' + dbPassword + '@' + data.host + ':' + data.port + '/' + data.database
 
@@ -150,7 +150,7 @@ installController.install = function (req, res) {
     fullname: data['account[fullname]']
   }
 
-  var dbPassword = encodeURIComponent(password)
+  var dbPassword = encodeURI(password)
   var conuri = 'mongodb://' + username + ':' + dbPassword + '@' + host + ':' + port + '/' + database
   if (port === '---') conuri = 'mongodb+srv://' + username + ':' + dbPassword + '@' + host + '/' + database
 


### PR DESCRIPTION
The dbPassword is being added as a part of the URI and hence should use encodeURI.  encodeURIComponent is right if the password was being sent as a query parameter.

This fixes an issue when using Azure Cosmos DB where the password is a base64 encoded string, which contains the '=' character.  This character should not be encoded as part of the URI.