### PR TITLE
fix: generate random key for the session secret

### DIFF
--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -72,7 +72,7 @@ module.exports = function (app, db, callback) {
     maxAge: 1000 * 60 * 60 * 24 * 365 // 1 year
   }
 
-  const sessionSecret = 'trudesk$123#SessionKeY!2387'
+  const sessionSecret = crypto.randomBytes(32).toString('hex');
   async.waterfall(
     [
       function (next) {


### PR DESCRIPTION
The session secret is currently hardcoded which can lead to potential security issues. I replaced the hardcoded `sessionSecret` by generating a random secret using the built-in crypto module.