### PR TITLE
Fix createUserFromEmail where email would not contain username and fullname

### DIFF
--- a/src/mailer/templates/public-account-created/index.handlebars
+++ b/src/mailer/templates/public-account-created/index.handlebars
@@ -20,11 +20,11 @@
 </head>
 <body>
 <div>
-    <p>Dear {{user.fullname}},</p>
+    <p>Dear {{fullname}},</p>
     <p>Welcome to Trudesk. Please click the link below to login with the following details:</p>
     <p>
         <a href="{{baseUrl}}">{{baseUrl}}</a> <br /><br />
-        <strong>Username: {{user.username}}</strong> <br />
+        <strong>Username: {{username}}</strong> <br />
         <strong>Password: {{plainTextPassword}}</strong>
     </p>
 </div>

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -576,6 +576,8 @@ userSchema.statics.createUserFromEmail = function (email, callback) {
 
             var dataObject = {
               user: savedUser,
+              username: savedUser.username,
+              fullname: savedUser.fullname,
               plainTextPassword: plainTextPass,
               baseUrl: setting.value
             }


### PR DESCRIPTION
Patch to fix issue #545 where a user created from email will fail to receive credentials in the confirmation mail.
Handlebars seems to have an issue with accessing properties not being owned by its parent :

```
Handlebars: Access has been denied to resolve the property "fullname" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details
Handlebars: Access has been denied to resolve the property "username" because it is not an "own property" of its parent.
You can add a runtime option to disable the check or this warning:
See https://handlebarsjs.com/api-reference/runtime-options.html#options-to-control-prototype-access for details
```

I couldn't figure a way to keep the template using `user.username` so I made a copy of these properties in `dataObject` and replaced these variables in the mail template.

I kept the original `user: savedUser` in `dataObject` just in case the callback was using it later to avoid breaking anything :

https://github.com/polonel/trudesk/blob/5bbc42395de7d2589daa97d6837500826448ac11/src/models/user.js#L599