### PR TITLE
fix: correct falied to failed typo in mongorestore error message

### DIFF
--- a/src/backup/restore.js
+++ b/src/backup/restore.js
@@ -117,7 +117,7 @@ function runRestore (file, callback) {
     if (code === 0) {
       callback(null, 'done')
     } else {
-      callback(new Error('mongorestore falied with code ' + code))
+      callback(new Error('mongorestore failed with code ' + code))
     }
   })
 }


### PR DESCRIPTION
Corrects `falied` to `failed` in the mongorestore error callback (src/backup/restore.js line 120).

This is a user-facing error message shown when mongorestore fails during backup restore operations.

**Before:** `mongorestore falied with code <exit_code>`
**After:** `mongorestore failed with code <exit_code>`

1 file changed, 1 line modified.