### PR TITLE
fix: correct 'falied' to 'failed' typo in mongorestore error message

### DIFF
--- a/src/backup/restore.js
+++ b/src/backup/restore.js
@@ -117,7 +117,7 @@ function runRestore (file, callback) {
     if (code === 0) {
       callback(null, 'done')
     } else {
-      callback(new Error('mongorestore falied with code ' + code))
+      callback(new Error('mongorestore failed with code ' + code))
     }
   })
 }


### PR DESCRIPTION
fix: correct 'falied' to 'failed' typo in mongorestore error message (src/backup/restore.js line 120).

User-facing Error message when mongorestore fails.